### PR TITLE
Improve metadata in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.5.2 (2019-02-20)
+
+- Improve metadata in package.json @davilima6
+
 ## 1.5.1 (2019-02-19)
 
 - Add missing extras to boilerplate @sneridagh

--- a/package.json
+++ b/package.json
@@ -1,16 +1,40 @@
 {
   "name": "@plone/create-volto-app",
-  "version": "1.5.1",
   "description": "Create Volto App",
-  "main": "index.js",
+  "homepage": "https://www.npmjs.com/package/@plone/create-volto-app",
+  "maintainers": [
+    {
+      "name": "Plone Foundation",
+      "email": "plone-developers@lists.sourceforge.net",
+      "url": "http://plone.org"
+    }
+  ],
   "license": "MIT",
-  "author": "",
-  "engines": {
-    "node": ">=6"
+  "version": "1.5.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/plone/create-volto-app.git"
   },
-  "repository": "",
+  "bugs": {
+    "url": "https://github.com/plone/create-volto-app/issues",
+    "email": "plone-developers@lists.sourceforge.net"
+  },
+  "keywords": [
+    "react",
+    "plone",
+    "volto",
+    "webpack",
+    "ssr",
+    "universal",
+    "isomorphic",
+    "pastanaga"
+  ],
+  "main": "index.js",
   "bin": {
     "create-volto-app": "./bin/create-volto-app.js"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "dependencies": {
     "ansi-escapes": "2.0.0",
@@ -24,15 +48,5 @@
     "mz": "2.6.0",
     "ora": "1.2.0",
     "promise": "7.1.1"
-  },
-  "keywords": [
-    "react",
-    "plone",
-    "volto",
-    "webpack",
-    "ssr",
-    "universal",
-    "isomorphic",
-    "pastanaga"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "create-volto-app": "./bin/create-volto-app.js"
   },
   "engines": {
-    "node": ">=6"
+    "node": "^8 || ^10"
   },
   "dependencies": {
     "ansi-escapes": "2.0.0",


### PR DESCRIPTION
I think this will add the repo Github link on Npm package page.

I changed some orders to be more similar to volto itself.

Should I add a commit to also copy Node's engine configuration so we increase the chance developers are using the same versions? I think Volto won't run on Node 6 (e.g. await keyword) so if developer manages to create app with Node 6, they may get surprised shortly next. Also for docs I think it'd look nicer if said we support the same versions. What do u think?