### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,31 @@
 
 [![Build Status](https://travis-ci.org/plone/create-volto-app.svg?branch=master)](https://travis-ci.org/plone/create-volto-app)
 
-Use: `create-volto-app <app-name>` for getting the boilerplate.
+Use: `npx @plone/create-volto-app <app-name>` for getting the boilerplate.
 
-### `yarn start`
+### `yarn start` or `npm start`
 
 Runs the project in development mode.
 You can view your application at http://localhost:3000
 
 The page will reload if you make edits.
 
-### `yarn build`
+### `yarn build` or `npm run build`
 
 Builds the app for production to the build folder.
 
 The build is minified and the filenames include the hashes. Your app is ready to be deployed!
 
-### `yarn start:prod`
+### `yarn start:prod` or `npm run start:prod`
 
 Runs the compiled app in production.
 
 You can again view your application at http://localhost:3000
 
-### `yarn test`
+### `yarn test`or `npm test`
 
 Runs the test watcher (Jest) in an interactive mode. By default, runs tests related to files changed since the last commit.
 
-### `yarn i18n`
+### `yarn i18n` or `npm run i18n`
 
 Runs the test i18n runner which extracts all the translation strings and generates the needed files.


### PR DESCRIPTION
- without `@plone/` prefix the old version is pulled.
- `npm` just works, `yarn` [can be difficult](https://github.com/yarnpkg/yarn/issues/1027) and is not mandatory.