### PR TITLE
Improve eslintrc in volto-starter-kit to cover more editor integration scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Improve .eslintrc in volto-starter-kit to cover more editor linting integration scenarios @tiberiuichim
+
 ## 6.2.3 (2020-06-19)
 
 ### Changes

--- a/volto-starter-kit/.eslintrc.js
+++ b/volto-starter-kit/.eslintrc.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const projectRootPath = path.resolve('.');
+const projectRootPath = __dirname;
 const packageJson = require(path.join(projectRootPath, 'package.json'));
 
 // Extends ESlint configuration for adding the aliases to `src` directories in Volto addons
@@ -13,14 +13,15 @@ if (packageJson.addons) {
 }
 
 module.exports = {
-  extends: './node_modules/@plone/volto/.eslintrc',
+  extends: `${projectRootPath}/node_modules/@plone/volto/.eslintrc`,
   settings: {
     'import/resolver': {
       alias: {
         map: [
           ['@plone/volto', '@plone/volto/src'],
           ...addonsAliases,
-          ['@package', './src'],
+          ['@package', `${__dirname}/src`],
+          ['~', `${__dirname}/src`],
         ],
         extensions: ['.js', '.jsx', '.json'],
       },


### PR DESCRIPTION
This covers my [setup](https://github.com/tiberiuichim/yadm-dotfiles/blob/34b90991cb5bad2598e74431f14b1d8ba3a00de0/.config/nvim/init.vim#L129) based on ALE.

I start vim with: `vim src/addons/my-addon` and the addon doesn't have its own eslintrc.