### PR TITLE
Add required create-sentry-release script used by Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 6.2.5 (unreleased)
+
+- Add create-sentry-release.sh script needed by Sentry @avoinea
+
 ## 6.2.4 (2020-08-05)
 
 ### Added

--- a/volto-starter-kit/create-sentry-release.sh
+++ b/volto-starter-kit/create-sentry-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+PARAM=$1
+if [ -z $PARAM ]; then
+  PARAM='not forced'
+fi
+if [ ! -z "$SENTRY_AUTH_TOKEN" ] && [ ! -z "$SENTRY_URL" ] && [ ! -z "$SENTRY_ORG" ] && [ ! -z "$SENTRY_PROJECT" ] && [ ! -z "$SENTRY_RELEASE" ]; then
+  CREATE=1
+  if [[ ! $PARAM = '--force' ]]; then
+    if ./node_modules/@sentry/cli/sentry-cli releases info $SENTRY_RELEASE | grep -q $SENTRY_RELEASE; then
+      CREATE=0
+    fi
+  fi
+  if [ $CREATE = 1 ]; then
+    ./node_modules/@sentry/cli/sentry-cli releases new $SENTRY_RELEASE
+    ./node_modules/@sentry/cli/sentry-cli releases files $SENTRY_RELEASE upload ./build/public/static/ --url-prefix "~/static"
+    ./node_modules/@sentry/cli/sentry-cli releases finalize $SENTRY_RELEASE
+  fi
+  if [ $CREATE = 0 ]; then
+    echo "Release $SENTRY_RELEASE already exists"
+    echo "Use --force if you still want to upload the source maps"
+  fi
+else
+  echo "SENTRY is not configured"
+fi


### PR DESCRIPTION
Docs says that you need to run `create-sentry-release.sh` but the script is not available within a volto-project